### PR TITLE
fix signal propagation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 ### General
 ```bash
-BRANCH="dspatch" # Change to whatever branch / tag you need
+BRANCH="standalone" # Change to whatever branch / tag you need
 git clone --recursive git@github.com:bu-cms/dtcq.git -b "${BRANCH}"
 cd dtcq
-git submodule update --init
 mkdir build
 cd build
 cmake ..

--- a/include/Ports.h
+++ b/include/Ports.h
@@ -5,7 +5,7 @@
 using namespace std;
 
 class Propagatable {
-	public:
+    public:
         virtual void propagate() = 0;
 };
 
@@ -38,11 +38,10 @@ class OutputPort: public Port<T>, public Propagatable {
 
         virtual void propagate() override{
             for(auto port: connected_ports) {
-                port->set_value(value);
+                port->set_value(Port<T>::value);
             }
         }
     protected:
-        T value;
         vector<InputPort<T>*> connected_ports;
 };
 

--- a/src/demo_fifo_verification.cc
+++ b/src/demo_fifo_verification.cc
@@ -63,7 +63,8 @@ public:
 			printf("\tNo source data produced.\n");
 		}
 		bool IN_FIFO_VALID = in_fifo_valid.get_value();
-		bool IN_FIFO_EMPTY = in_fifo_empty.get_value();
+		bool FIFO_EMPTY_LAST_TICK = FIFO_EMPTY_THIS_TICK;
+		bool FIFO_EMPTY_THIS_TICK = in_fifo_empty.get_value();
 		if (IN_FIFO_VALID)
 		{
 			if (src_data.empty()) printf("\tsrc_data empty! something wrong?\n");
@@ -75,17 +76,20 @@ public:
 		}
 		else if (READ_IN_LAST_TICK)
 		{
-			if (IN_FIFO_EMPTY) printf("\tWas tring to read from FIFO but FIFO empty. good!\n");
+			if (FIFO_EMPTY_LAST_TICK) printf("\tWas tring to read from FIFO but FIFO empty. good!\n");
 			else printf("\tWas tring to read from FIFO but no data comes out. so bad!\n");
 		}
 		else printf("\tNo data comes out from FIFO and wasn't trying to read. so good!\n");
-		READ_IN_LAST_TICK = ( rand()%2==0 );
-		out_fifo_read.set_value(READ_IN_LAST_TICK);
+		READ_IN_LAST_TICK = READ_IN_THIS_TICK;
+		READ_IN_THIS_TICK = ( rand()%2==0 );
+		out_fifo_read.set_value(READ_IN_THIS_TICK);
     };
 protected:
 	std::queue<uint64_t> src_data;
 	bool READ_IN_THIS_TICK = false;
 	bool READ_IN_LAST_TICK = false;
+	bool FIFO_EMPTY_LAST_TICK = true;
+	bool FIFO_EMPTY_THIS_TICK = true;
 	int tick_counter = 0;
 };
 


### PR DESCRIPTION
Seems that we just defined an extra "value" in the derived class OutputPort, so the "value" gets propagated and the "value" in set_value are different objects.
Also fixed the "FIFO_EMPTY_LAST_TICK" flag